### PR TITLE
docs(test-projects-js.md): fix wrong baseUrl in "Configure projects…" section

### DIFF
--- a/docs/src/test-projects-js.md
+++ b/docs/src/test-projects-js.md
@@ -112,14 +112,14 @@ export default defineConfig({
     {
       name: 'staging',
       use: {
-        baseURL: 'staging.example.com',
+        baseURL: 'https://staging.example.com',
       },
       retries: 2,
     },
     {
       name: 'production',
       use: {
-        baseURL: 'production.example.com',
+        baseURL: 'https://production.example.com',
       },
       retries: 0,
     },


### PR DESCRIPTION
A small PR to add missing https in the "Configure projects for multiple environments" section